### PR TITLE
Refactor throwError to orOnErrorThrow

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ Pattern matching can be used to check unknown result value as shown above.
 
 ````java
 Result<String, Integer> receivedResult = ...;
-String value = receivedResult.throwError(code -> new IOException("%s: error".formatted(code)));
+String value = receivedResult.orOnErrorThrow(code -> new IOException("%s: error".formatted(code)));
 System.out.println(value);
 ````
 
 Instead of a low-level pattern-matching,
 higher level helper-methods are available in `Result`-class.
-In the snippet above `throwError` is used to throw exception when `Result` contains error.
+In the snippet above `orOnErrorThrow` is used to throw exception when `Result` contains error.
 
 Result-type is created for interoperability between normal Java-code that throws exception and
 more functional code.
@@ -85,7 +85,7 @@ String concatenation =
         Stream.of("a.txt", "b.txt", "c.txt")
                 .map(io.catching(name -> loadResource(name)))
                 .collect(ResultCollectors.toSingleResult(Collectors.join()))
-                .throwError(Function.identity());
+                .orOnErrorThrow(Function.identity());
 ````
 
 Above code uses `Catcher` class to adapt functions that
@@ -107,7 +107,7 @@ class MyMain {
             Catcher.of(IOException.class).forFunctions();
         Function<String, Result<String, IOException>> f = io.catching(MyMain::loadResult);
         Result<String, IOException> result = f.apply("my-resource");
-        String value = result.throwError(Function.identity());
+        String value = result.orOnErrorThrow(Function.identity());
         System.out.println(value);
     }
 }
@@ -130,6 +130,6 @@ List<Animal> animals1 =
                 .map(io.catching(Fakes::readFile))
                 .map(Result.flatMapping(ml.catching(Fakes::recognizeImage)))
                 .collect(ResultCollectors.toSingleResult(Collectors.toList()))
-                .throwError(Function.identity());
+                .orOnErrorThrow(Function.identity());
 Assertions.assertEquals(List.of(Animal.CAT, Animal.DOG), animals1);
 ````

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <packaging>jar</packaging>
     <groupId>com.github.sviperll</groupId>
     <artifactId>result4j</artifactId>
-    <version>1.1.5-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <name>result4j</name>
     <url>https://github.com/sviperll/result4j</url>
     <description>

--- a/src/main/java/com/github/sviperll/result4j/AdaptingCatcher.java
+++ b/src/main/java/com/github/sviperll/result4j/AdaptingCatcher.java
@@ -77,7 +77,7 @@ import java.util.function.Supplier;
  *                     // @highlight substring="ml" type="highlighted" :
  *                     .map(Result.flatMapping(ml.catching(Fakes::recognizeImage)))
  *                     .collect(ResultCollectors.toSingleResult(Collectors.toList()))
- *                     .throwError(Function.identity());
+ *                     .orOnErrorThrow(Function.identity());
  * }
  * <p>
  * In the example above two methods are used {@code readFile} and {@code recognizeImage}.

--- a/src/main/java/com/github/sviperll/result4j/Result.java
+++ b/src/main/java/com/github/sviperll/result4j/Result.java
@@ -76,7 +76,7 @@ import java.util.function.Function;
  * {@snippet lang="java" :
  *     Result<String, Integer> receivedResult = ...;
  *     String value =
- *             receivedResult.throwError(
+ *             receivedResult.orOnErrorThrow(
  *                     code -> new IOException("%s: error".formatted(code))
  *             );
  *     System.out.println(value);
@@ -84,7 +84,7 @@ import java.util.function.Function;
  * <p>
  * Instead of a low-level pattern-matching,
  * higher level helper-methods are available in {@code Result}-class.
- * In the snippet above {@link Result#throwError(Function)} is used to throw exception when
+ * In the snippet above {@link Result#orOnErrorThrow(Function)} is used to throw exception when
  * {@code Result} contains error.
  *
  * {@snippet lang="java" :
@@ -92,7 +92,7 @@ import java.util.function.Function;
  *             Stream.of("a.txt", "b.txt", "c.txt")
  *                     .map(name -> loadFile(name))
  *                     .collect(ResultCollectors.toSingleResult(Collectors.join()))
- *                     .throwError(Function.identity());
+ *                     .orOnErrorThrow(Function.identity());
  * }
  * <p>
  * In the above example we expect that the {@code loadFile} method returns the {@code Result}-type
@@ -391,8 +391,26 @@ public sealed interface Result<R, E> {
      * @param errorToExceptionConverter function to convert error-value to an exception
      * @return the value of this result, when it is a successful result
      * @throws X when this is an error result
+     * @deprecated use {@link #orOnErrorThrow(Function)} instead
      */
+    @Deprecated(forRemoval = true, since = "1.2.0")
     default <X extends Exception> R throwError(Function<? super E, X> errorToExceptionConverter)
+            throws X {
+        return orOnErrorThrow(errorToExceptionConverter);
+    }
+
+    /**
+     * Throws an exception, by converting error-value to an exception instance.
+     * <p>
+     * Returns the value of this result when this is a successful result, or otherwise
+     * throws an exception, by creating exception instance from error-value.
+     *
+     * @param <X> type of thrown exception
+     * @param errorToExceptionConverter function to convert error-value to an exception
+     * @return the value of this result, when it is a successful result
+     * @throws X when this is an error result
+     */
+    default <X extends Exception> R orOnErrorThrow(Function<? super E, X> errorToExceptionConverter)
             throws X {
         return switch (this) {
             case Success<R, E> success -> success.result;

--- a/src/main/java/com/github/sviperll/result4j/package-info.java
+++ b/src/main/java/com/github/sviperll/result4j/package-info.java
@@ -43,7 +43,7 @@
  *             Stream.of("a.txt", "b.txt", "c.txt")
  *                     .map(io.catching(name -> loadResource(name)))
  *                     .collect(ResultCollectors.toSingleResult(Collectors.join()))
- *                     .throwError(Function.identity());
+ *                     .orOnErrorThrow(Function.identity());
  * }
  * <p>
  * Above code uses {@link Catcher} class to adapt functions that
@@ -69,7 +69,7 @@
  *                     .map(io.catching(Fakes::readFile))
  *                     .map(Result.flatMapping(ml.catching(Fakes::recognizeImage)))
  *                     .collect(ResultCollectors.toSingleResult(Collectors.toList()))
- *                     .throwError(Function.identity());
+ *                     .orOnErrorThrow(Function.identity());
  *     Assertions.assertEquals(List.of(Animal.CAT, Animal.DOG), animals1);
  * }
  */

--- a/src/test/java/com/github/sviperll/result4j/ResultCollectorsTest.java
+++ b/src/test/java/com/github/sviperll/result4j/ResultCollectorsTest.java
@@ -39,7 +39,7 @@ public class ResultCollectorsTest {
                         .collect(ResultCollectors.toSingleResult(Collectors.toList()));
         Assertions.assertThrows(
                 NumberFormatException.class,
-                () -> result.throwError(Function.identity())
+                () -> result.orOnErrorThrow(Function.identity())
         );
     }
 
@@ -51,7 +51,7 @@ public class ResultCollectorsTest {
                 Stream.of("123", "234", "456")
                         .map(numberFormat.catching(Integer::parseInt))
                         .collect(ResultCollectors.toSingleResult(Collectors.toList()))
-                        .throwError(Function.identity());
+                        .orOnErrorThrow(Function.identity());
         Assertions.assertEquals(List.of(123, 234, 456), result);
     }
 
@@ -65,7 +65,7 @@ public class ResultCollectorsTest {
                         .collect(ResultCollectors.toSingleResult(Collectors.toList()));
         Assertions.assertThrows(
                 RuntimeException.class,
-                () -> result.throwError(Function.identity())
+                () -> result.orOnErrorThrow(Function.identity())
         );
     }
 
@@ -77,7 +77,7 @@ public class ResultCollectorsTest {
                 Stream.of("123", "234", "456")
                         .map(numberFormat.catching(Integer::parseInt))
                         .collect(ResultCollectors.toSingleResult(Collectors.toList()))
-                        .throwError(Function.identity());
+                        .orOnErrorThrow(Function.identity());
         Assertions.assertEquals(List.of(123, 234, 456), result);
     }
 
@@ -93,7 +93,7 @@ public class ResultCollectorsTest {
                         .map(io.catching(Fakes::readFile))
                         .map(Result.flatMapping(ml.catching(Fakes::recognizeImage)))
                         .collect(ResultCollectors.toSingleResult(Collectors.toList()))
-                        .throwError(Function.identity());
+                        .orOnErrorThrow(Function.identity());
         Assertions.assertEquals(List.of(Animal.CAT, Animal.DOG), animals1);
     }
 
@@ -112,7 +112,7 @@ public class ResultCollectorsTest {
         PipelineException exception =
                 Assertions.assertThrows(
                         PipelineException.class,
-                        () -> animals.throwError(Function.identity())
+                        () -> animals.orOnErrorThrow(Function.identity())
                 );
         Assertions.assertInstanceOf(IOException.class, exception.getCause());
     }
@@ -132,7 +132,7 @@ public class ResultCollectorsTest {
         PipelineException exception =
                 Assertions.assertThrows(
                         PipelineException.class,
-                        () -> animals.throwError(Function.identity())
+                        () -> animals.orOnErrorThrow(Function.identity())
                 );
         Assertions.assertInstanceOf(MLException.class, exception.getCause());
     }


### PR DESCRIPTION
In my opinion `throwError` methods suggest that the error always be thrown.
What about changing the name to `orOnErrorThrow`?