### PR TITLE
Change ResultAssert methods.

### DIFF
--- a/result4j-assertj/src/main/java/com/github/sviperll/result4jassertj/ResultAssert.java
+++ b/result4j-assertj/src/main/java/com/github/sviperll/result4jassertj/ResultAssert.java
@@ -20,17 +20,15 @@
 package com.github.sviperll.result4jassertj;
 
 import com.github.sviperll.result4j.Result;
-import java.util.Objects;
-import java.util.function.Consumer;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ObjectAssert;
 
 /**
  * AssertJ {@link org.assertj.core.api.Assert assertions} that can be applied to a {@link Result}.
  *
  * @param <R> type of successful result value.
  * @param <E> type representing error.
- *
  * @see Result
  * @see <a href="https://assertj.github.io/doc/">AssertJ</a>
  * @since 1.2.0
@@ -59,188 +57,60 @@ public class ResultAssert<R, E> extends AbstractAssert<ResultAssert<R, E>, Resul
     }
 
     /**
-     * Verifies that the {@link Result} represents Error.
+     * Verifies that the {@link Result} represents Error, and returns an
+     * assertion object for the Error value.
+     * <p>
+     * The returned assertion can be used to perform more assertions on an Error value object.
      * <p>
      * Example:
+     * <p>
+     * {@snippet lang = "java":
+     *     assertThat(result)
+     *         .hasErrorThat()
+     *         .asInstanceOf(InstanceOfAssertFactories.THROWABLE)
+     *         .isExactlyInstanceOf(RuntimeException.class)
+     *         .cause()
+     *         .isExactlyInstanceOf(NumberFormatException.class)
+     *         .hasMessage("For input string: \"xyz\"");
+     *}
      *
-     * {@snippet lang="java":
-     *     assertThat(result).isError();
-     * }
-     *
-     * @return {@code this} assertion object.
+     * @return assertion object for Error.
      * @throws AssertionError if the {@code Result} represents Success.
      */
-    public ResultAssert<R, E> isError() {
+    public ObjectAssert<E> hasErrorThat() {
         isNotNull();
-        Assertions.assertThat(actual.isError()).describedAs("Check if Result is an Error").isTrue();
-        return myself;
-    }
 
-    /**
-     * Verifies that the {@link Result} represents Success.
-     * <p>
-     * Example:
-     *
-     * {@snippet lang="java":
-     *     assertThat(result).isSuccess();
-     * }
-     *
-     * @return {@code this} assertion object.
-     * @throws AssertionError if the {@code Result} represents Error.
-     */
-    public ResultAssert<R, E> isSuccess() {
-        isNotNull();
-        Assertions.assertThat(actual.isError())
-                .describedAs("Check if Result is a Success")
-                .isFalse();
-        return myself;
-    }
-
-    /**
-     * Verifies that the {@link Result} represents Error and the error value
-     * is equal to the expected value.
-     * <p>
-     * Example:
-     *
-     * {@snippet lang="java":
-     *     assertThat(result).hasErrorEqualTo(expectedError);
-     * }
-     *
-     * @param expectedError the expected error value.
-     * @return {@code this} assertion object.
-     * @throws AssertionError if the {@code Result} represents Success or
-     *     the error value is not equal to the expected value.
-     */
-    public ResultAssert<R, E> hasErrorEqualTo(E expectedError) {
-        isNotNull();
-        Assertions.assertThat(actualError())
-                .describedAs("Check Result Error")
-                .isEqualTo(expectedError);
-        return myself;
-    }
-
-    /**
-     * Verifies that the Error value object satisfied the given requirements
-     * expressed as {@link Consumer}.
-     * This is terminal operation of this assertion chain.
-     * <p>
-     * This is useful to perform an assertions on an Error value object,
-     * passed assertion is evaluated and all failures are reported.
-     * <p>
-     * Example:
-     *
-     * {@snippet lang="java":
-     *     Result result =
-     *             Result.error(
-     *                     new IllegalArgumentException("Name is invalid")
-     *             );
-     *
-     *     // assertions succeed:
-     *     ResultAssert.assertThat(result)
-     *             .isError()
-     *             .hasErrorThat(
-     *                     error ->
-     *                             Assertions.assertThat(error)
-     *                                     .isInstanceOf(IllegalArgumentException.class)
-     *                                     .hasMessage("Name is invalid")
-     *             );
-     *
-     *     // assertion fails:
-     *     ResultAssert.assertThat(result)
-     *             .isError()
-     *             .hasErrorThat(
-     *                     error ->
-     *                             Assertions.assertThat(error)
-     *                                     .isInstanceOf(NullPointerException.class)
-     *                                     .hasMessage("Name is invalid")
-     *             );
-     * }
-     *
-     * @param consumer the consumer to assert the Error value object — must not be {@code null}.
-     * @throws NullPointerException if Consumer is {@code null}.
-     */
-    public void hasErrorThat(Consumer<? super E> consumer) {
-        Objects.requireNonNull(consumer, "Error value consumer should be non null");
-        isNotNull();
-        consumer.accept(actualError());
-    }
-
-    /**
-     * Verifies that the {@link Result} represents Success and
-     * the success value is equal to the expected value.
-     * <p>
-     * Example:
-     *
-     * {@snippet lang="java":
-     *     assertThat(result).hasSuccessEqualTo(expectedSuccess);
-     * }
-     *
-     * @param expectedSuccess the expected success value.
-     * @return {@code this} assertion object.
-     * @throws AssertionError if the {@code Result} represents Error or
-     *     the success value is not equal to the expected value.
-     */
-    public ResultAssert<R, E> hasSuccessEqualTo(R expectedSuccess) {
-        isNotNull();
-        Assertions.assertThat(actualSuccess())
-                .describedAs("Check Result Success")
-                .isEqualTo(expectedSuccess);
-        return myself;
-    }
-
-    /**
-     * Verifies that the Success value object satisfied the given requirements
-     * expressed as {@link Consumer}.
-     * This is terminal operation of this assertion chain.
-     * <p>
-     * This is useful to perform an assertions on a Success value object,
-     * passed assertion is evaluated and all failures are reported.
-     * <p>
-     * Example:
-     * {@snippet lang="java":
-     *     Result result = Result.success(List.of("one", "two", "three"));
-     *
-     *     // assertions succeed:
-     *     ResultAssert.assertThat(result)
-     *             .isSuccess()
-     *             .hasSuccessThat(
-     *                     success ->
-     *                             Assertions.assertThat(success)
-     *                                     .hasSize(3)
-     *                                     .containsExactlyInAnyOrder("three", "two", "one")
-     *             );
-     *
-     *     // assertion fails:
-     *     ResultAssert.assertThat(result)
-     *             .isSuccess()
-     *             .hasSuccessThat(
-     *                     success ->
-     *                             Assertions.assertThat(success)
-     *                                     .hasSize(2)
-     *                                     .containsExactly("three", "two", "one")
-     *             );
-     *  }
-     *
-     * @param consumer the consumer to assert the Success value object — must not be {@code null}.
-     * @throws NullPointerException if Consumer is {@code null}.
-     */
-    public void hasSuccessThat(Consumer<? super R> consumer) {
-        Objects.requireNonNull(consumer, "Success value consumer should be non null");
-        isNotNull();
-        consumer.accept(actualSuccess());
-    }
-
-    private E actualError() {
         if (actual instanceof Result.Error(E error)) {
-            return error;
+            return Assertions.assertThat(error);
         }
         throw failure("Expected Result to be Error but was Success");
     }
 
-    private R actualSuccess() {
+    /**
+     * Verifies that the {@link Result} represents Success, and returns an
+     * assertion object for the Success value.
+     * <p>
+     * The returned assertion can be used to perform more assertions on a Success value object.
+     * <p>
+     * Example:
+     * <p>
+     * {@snippet lang = "java":
+     *     assertThat(result)
+     *         .hasSuccessThat()
+     *         .asInstanceOf(list(Integer.class))
+     *         .containsExactlyInAnyOrderElementsOf(List.of(123, 456, 234));
+     *}
+     *
+     * @return assertion object for Success value.
+     * @throws AssertionError if the {@code Result} represents Error.
+     */
+    public ObjectAssert<R> hasSuccessThat() {
+        isNotNull();
+
         if (actual instanceof Result.Success(R result)) {
-            return result;
+            return Assertions.assertThat(result);
         }
         throw failure("Expected Result to be Success but was Error");
     }
+
 }

--- a/result4j-assertj/src/test/java/com/github/sviperll/result4jassertj/ResultCollectorsTest.java
+++ b/result4j-assertj/src/test/java/com/github/sviperll/result4jassertj/ResultCollectorsTest.java
@@ -26,14 +26,13 @@ import com.github.sviperll.result4j.ResultCollectors;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Assertions;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 
 import static com.github.sviperll.result4jassertj.ResultAssert.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.list;
 
 public class ResultCollectorsTest {
     @Test
@@ -44,24 +43,27 @@ public class ResultCollectorsTest {
                 Stream.of("123", "234", "xvxv", "456")
                         .map(numberFormat.catching(Integer::parseInt))
                         .collect(ResultCollectors.toSingleResult(Collectors.toList()));
+
         assertThat(result)
-                    .isError()
-                    .hasErrorThat(
-                            exception ->
-                                assertThat(exception)
-                                    .isInstanceOf(NumberFormatException.class));
+                .hasErrorThat()
+                .asInstanceOf(InstanceOfAssertFactories.THROWABLE)
+                .isExactlyInstanceOf(NumberFormatException.class)
+                .hasMessage("For input string: \"xvxv\"");
     }
 
     @Test
     public void nonAdaptedRuntimeExceptionSuccess() {
         Catcher.ForFunctions<NumberFormatException> numberFormat =
                 Catcher.of(NumberFormatException.class).forFunctions();
-        List<Integer> result =
+        Result<List<Integer>, NumberFormatException> result =
                 Stream.of("123", "234", "456")
                         .map(numberFormat.catching(Integer::parseInt))
-                        .collect(ResultCollectors.toSingleResult(Collectors.toList()))
-                        .orOnErrorThrow(Function.identity());
-        Assertions.assertEquals(List.of(123, 234, 456), result);
+                        .collect(ResultCollectors.toSingleResult(Collectors.toList()));
+
+        assertThat(result)
+                .hasSuccessThat()
+                .asInstanceOf(list(Integer.class))
+                .containsExactlyInAnyOrderElementsOf(List.of(456, 234, 123));
     }
 
     @Test
@@ -72,78 +74,89 @@ public class ResultCollectorsTest {
                 Stream.of("123", "234", "xvxv", "456")
                         .map(numberFormat.catching(Integer::parseInt))
                         .collect(ResultCollectors.toSingleResult(Collectors.toList()));
-        Assertions.assertThrows(
-                RuntimeException.class,
-                () -> result.orOnErrorThrow(Function.identity())
-        );
+
+        assertThat(result)
+                .hasErrorThat()
+                .asInstanceOf(InstanceOfAssertFactories.THROWABLE)
+                .isExactlyInstanceOf(RuntimeException.class)
+                .cause()
+                .isExactlyInstanceOf(NumberFormatException.class)
+                .hasMessage("For input string: \"xvxv\"");
     }
 
     @Test
     public void adaptedRuntimeExceptionSuccess() {
         AdaptingCatcher.ForFunctions<NumberFormatException, RuntimeException> numberFormat =
                 Catcher.of(NumberFormatException.class).forFunctions().map(RuntimeException::new);
-        List<Integer> result =
+        Result<List<Integer>, RuntimeException> result =
                 Stream.of("123", "234", "456")
                         .map(numberFormat.catching(Integer::parseInt))
-                        .collect(ResultCollectors.toSingleResult(Collectors.toList()))
-                        .orOnErrorThrow(Function.identity());
-        Assertions.assertEquals(List.of(123, 234, 456), result);
+                        .collect(ResultCollectors.toSingleResult(Collectors.toList()));
+
+        assertThat(result)
+                .hasSuccessThat()
+                .asInstanceOf(list(Integer.class))
+                .containsExactlyInAnyOrderElementsOf(List.of(123, 456, 234));
     }
 
     @Test
-    public void multipleAdaptedCheckedExceptionsSuccess() throws PipelineException {
-        AdaptingCatcher.ForFunctions<IOException, PipelineException> io =
-                Catcher.of(IOException.class).map(PipelineException::new).forFunctions();
-        AdaptingCatcher.ForFunctions<MLException, PipelineException> ml =
-                Catcher.of(MLException.class).map(PipelineException::new).forFunctions();
-        List<Animal> animals1 =
-                List.of("cat.jpg", "dog.jpg")
-                        .stream()
-                        .map(io.catching(Fakes::readFile))
-                        .map(Result.flatMapping(ml.catching(Fakes::recognizeImage)))
-                        .collect(ResultCollectors.toSingleResult(Collectors.toList()))
-                        .orOnErrorThrow(Function.identity());
-        Assertions.assertEquals(List.of(Animal.CAT, Animal.DOG), animals1);
-    }
-
-    @Test
-    public void multipleAdaptedCheckedExceptionsFailure1() throws PipelineException {
+    public void multipleAdaptedCheckedExceptionsSuccess() {
         AdaptingCatcher.ForFunctions<IOException, PipelineException> io =
                 Catcher.of(IOException.class).map(PipelineException::new).forFunctions();
         AdaptingCatcher.ForFunctions<MLException, PipelineException> ml =
                 Catcher.of(MLException.class).map(PipelineException::new).forFunctions();
         Result<List<Animal>, PipelineException> animals =
-                List.of("cat.jpg", "dog.jpg", "non-existent.jpg")
-                        .stream()
+                Stream.of("cat.jpg", "dog.jpg")
                         .map(io.catching(Fakes::readFile))
                         .map(Result.flatMapping(ml.catching(Fakes::recognizeImage)))
                         .collect(ResultCollectors.toSingleResult(Collectors.toList()));
-        PipelineException exception =
-                Assertions.assertThrows(
-                        PipelineException.class,
-                        () -> animals.orOnErrorThrow(Function.identity())
-                );
-        Assertions.assertInstanceOf(IOException.class, exception.getCause());
+
+        assertThat(animals)
+                .hasSuccessThat()
+                .asInstanceOf(list(Animal.class))
+                .containsExactlyInAnyOrderElementsOf(List.of(Animal.CAT, Animal.DOG));
     }
 
     @Test
-    public void multipleAdaptedCheckedExceptionsFailure2() throws PipelineException {
+    public void multipleAdaptedCheckedExceptionsFailure1() {
         AdaptingCatcher.ForFunctions<IOException, PipelineException> io =
                 Catcher.of(IOException.class).map(PipelineException::new).forFunctions();
         AdaptingCatcher.ForFunctions<MLException, PipelineException> ml =
                 Catcher.of(MLException.class).map(PipelineException::new).forFunctions();
         Result<List<Animal>, PipelineException> animals =
-                List.of("cat.jpg", "dog.jpg", "corrupted.jpg")
-                        .stream()
+                Stream.of("cat.jpg", "dog.jpg", "non-existent.jpg")
                         .map(io.catching(Fakes::readFile))
                         .map(Result.flatMapping(ml.catching(Fakes::recognizeImage)))
                         .collect(ResultCollectors.toSingleResult(Collectors.toList()));
-        PipelineException exception =
-                Assertions.assertThrows(
-                        PipelineException.class,
-                        () -> animals.orOnErrorThrow(Function.identity())
-                );
-        Assertions.assertInstanceOf(MLException.class, exception.getCause());
+
+
+        assertThat(animals)
+                .hasErrorThat()
+                .asInstanceOf(InstanceOfAssertFactories.THROWABLE)
+                .isExactlyInstanceOf(PipelineException.class)
+                .cause()
+                .isInstanceOf(IOException.class)
+                .hasMessage("non-existent.jpg: not found");
+    }
+
+    @Test
+    public void multipleAdaptedCheckedExceptionsFailure2() {
+        AdaptingCatcher.ForFunctions<IOException, PipelineException> io =
+                Catcher.of(IOException.class).map(PipelineException::new).forFunctions();
+        AdaptingCatcher.ForFunctions<MLException, PipelineException> ml =
+                Catcher.of(MLException.class).map(PipelineException::new).forFunctions();
+        Result<List<Animal>, PipelineException> animals =
+                Stream.of("cat.jpg", "dog.jpg", "corrupted.jpg")
+                        .map(io.catching(Fakes::readFile))
+                        .map(Result.flatMapping(ml.catching(Fakes::recognizeImage)))
+                        .collect(ResultCollectors.toSingleResult(Collectors.toList()));
+
+        assertThat(animals)
+                .hasErrorThat()
+                .asInstanceOf(InstanceOfAssertFactories.THROWABLE)
+                .isExactlyInstanceOf(PipelineException.class)
+                .cause()
+                .isExactlyInstanceOf(MLException.class);
     }
 
     enum Animal {


### PR DESCRIPTION
- change hasErrorThat to be as one that we have discussed
- remove unnecessary specializations (hasErrorEqualTo, hasSuccessEqualTo)
- convert all the tests in ResultCollectorsTest.java in result4j-assertj to use ResultAssert or remove those that do not need ResultAssert